### PR TITLE
feat: `reversed_sorter_apply_order`

### DIFF
--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -182,6 +182,12 @@ where
         self
     }
 
+    /// Reverses the application order of sorters.
+    ///
+    /// By default, sorters are applied in the order they are added. If this flag is set to `true`,
+    /// they will be applied in the reverse order of addition. This is useful when you want the
+    /// last-added sorter to have the highest priority in sorting.
+    /// The default value is `false`.
     pub fn reversed_sorter_apply_order(mut self, flag: bool) -> Self {
         self.batcher.reversed_sorter_apply_order = flag;
         self

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -182,6 +182,11 @@ where
         self
     }
 
+    pub fn reversed_sorter_apply_order(mut self, flag: bool) -> Self {
+        self.batcher.reversed_sorter_apply_order = flag;
+        self
+    }
+
     /// A batch represents the process of retrieving items from all available sources and sorting the filtered items
     /// according to user-specified sorters.
     ///

--- a/src/launcher/batcher.rs
+++ b/src/launcher/batcher.rs
@@ -144,9 +144,9 @@ where
             let lhs = &self.state.items[*lhs];
             let rhs = &self.state.items[*rhs];
 
-            macro_rules! compare {
-                ($i:ident) => {
-                    match self.sorters[$i].compare(lhs, rhs, &self.state.input) {
+            if self.reversed_sorter_apply_order {
+                for i in (0..self.sorters.len()).rev() {
+                    match self.sorters[i].compare(lhs, rhs, &self.state.input) {
                         Ordering::Equal => {
                             continue;
                         }
@@ -158,16 +158,21 @@ where
                             };
                         }
                     }
-                };
-            }
-
-            if self.reversed_sorter_apply_order {
-                for i in (0..self.sorters.len()).rev() {
-                    compare!(i)
                 }
             } else {
                 for i in 0..self.sorters.len() {
-                    compare!(i)
+                    match self.sorters[i].compare(lhs, rhs, &self.state.input) {
+                        Ordering::Equal => {
+                            continue;
+                        }
+                        ord => {
+                            return if self.reverse_sorter {
+                                ord.reverse()
+                            } else {
+                                ord
+                            };
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to reverse the order in which sorting rules are applied when displaying results. Users can now choose whether sorters are processed from first-to-last or last-to-first, offering more flexibility in sorting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->